### PR TITLE
Interdire toutes les pages admin aux utilisateurs non-admin

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -7,6 +7,7 @@ use App\Models\Poll;
 use GuzzleHttp\Psr7\UploadedFile;
 use http\Env\Request;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use Illuminate\View\View;
@@ -16,6 +17,8 @@ class AdminController extends Controller
 {
     public function createPoll(): View|RedirectResponse
     {
+        Gate::authorize('doAdminActions');
+
         $poll = new Poll();
         $poll->title = 'New Poll';
         return view('admin.createPoll', ['poll' => $poll]);
@@ -23,21 +26,29 @@ class AdminController extends Controller
 
     public function storePoll(FormPollRequest $request): RedirectResponse
     {
+        Gate::authorize('doAdminActions');
+
         Poll::create($this->extractData(new Poll(), $request));
         return redirect()->route('polls')->with('success', 'Poll created successfully.');
     }
 
     public function updatePoll(Poll $poll, FormPollRequest $request): RedirectResponse
     {
+        Gate::authorize('doAdminActions');
+
         $poll->update($this->extractData($poll, $request));
         return redirect()->route('polls')->with('success', 'Poll updated successfully.');
     }
 
     public function editPoll(Poll $poll): View|RedirectResponse {
+        Gate::authorize('doAdminActions');
+
         return view('admin.createPoll', ['poll' => $poll]);
     }
 
     public function extractData(Poll $poll, FormPollRequest $request): array {
+        Gate::authorize('doAdminActions');
+
         $data = $request->validated();
         /** @var UploadedFile|null $image */;
         $image = $request->validated('image');
@@ -52,6 +63,8 @@ class AdminController extends Controller
     }
 
     public function index(): View {
+        Gate::authorize('doAdminActions');
+
         $polls = Poll::orderBy('published_at', 'desc')->paginate(5);
         return view('admin.index', ['polls' => $polls]);
     }

--- a/app/Http/Requests/FormPollRequest.php
+++ b/app/Http/Requests/FormPollRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
-use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Str;
 
 class FormPollRequest extends FormRequest
@@ -13,7 +13,7 @@ class FormPollRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        return Auth::user()->is_admin;
+        return Gate::allows('doAdminActions');
     }
 
     /**

--- a/app/Policies/AdminPolicy.php
+++ b/app/Policies/AdminPolicy.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\User;
+
+class AdminPolicy
+{
+    // Pas plus de détails pour le moment, l'admin a tous les droits.
+    public function doAdminActions(User $user): bool
+    {
+        return $user->is_admin;
+    }
+}

--- a/resources/views/app/account.blade.php
+++ b/resources/views/app/account.blade.php
@@ -22,7 +22,7 @@
                     @auth()
 
                 </div>
-                @if(\Illuminate\Support\Facades\Auth::user()->is_admin)
+                @can('doAdminActions')
                     <div>
 
                         <form action="{{ route('admin.index') }}" method="get">


### PR DESCRIPTION
N'importe quel utilisateur peut accéder à l'admin car il n'y a pas de check de rôle